### PR TITLE
Fix for compilation failure, seen on Ubuntu 11.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ vmsplice_coop_pipe_thr.o: vmsplice_pipe_thr.c
 	$(CC) $(CFLAGS) $^ -c -DVMSPLICE_COOP -o $@
 
 summarise_tsc_counters: summarise_tsc_counters.o stats.o
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 clean:
 	rm -f *~ core *.o $(TARGETS)


### PR DESCRIPTION
cc -lm -lrt -lnuma  summarise_tsc_counters.o stats.o   -o summarise_tsc_counters
    stats.o: In function `calc_summary_stats':
    /home/trj/crap/ipc/ipc-bench/stats.c:58: undefined reference to`sqrt'
    collect2: ld returned 1 exit status
    make: **\* [summarise_tsc_counters] Error 1

Was failing on Ubuntu 11.10
