### PR TITLE
Fix build errors when assertions are enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,6 @@ ifeq ($(uname),Darwin)
 all_target := darwin
 endif
 
-CFLAGS = -g -Wall -O3 -D_GNU_SOURCE -DNDEBUG -std=gnu99
-
 .PHONY: all clean run
 
 CFLAGS_Linux = -DUSE_INLINE_ASM -DLinux

--- a/pipe_thr.c
+++ b/pipe_thr.c
@@ -81,7 +81,7 @@ static void
 release_read_buf(test_data *td, struct iovec* vecs, int n_vecs) {
   pipe_state *ps = (pipe_state *)td->data;  
   assert(n_vecs == 1);
-  assert(vecs == ps->buffer);
+  assert(vecs == &ps->buffer);
 }
 
 static void child_fin(test_data *td) {
@@ -102,7 +102,7 @@ static void
 release_write_buf(test_data *td, struct iovec* vecs, int n_vecs)
 {
   pipe_state *ps = (pipe_state *)td->data;
-  assert(vecs == ps->buffer && n_vecs == 1);
+  assert(vecs == &ps->buffer && n_vecs == 1);
   xwrite(ps->fds[1], vecs[0].iov_base, vecs[0].iov_len);
 }
 

--- a/tcp_thr.c
+++ b/tcp_thr.c
@@ -127,7 +127,7 @@ static void
 release_read_buf(test_data *td, struct iovec* vecs, int n_vecs) {
   struct tcp_state *ps = (struct tcp_state *)td->data;  
   assert(n_vecs == 1);
-  assert(vecs == ps->buffer);
+  assert(vecs == &ps->buffer);
 }
 
 static struct iovec* get_write_buf(test_data *td, int len, int* n_vecs) {
@@ -141,7 +141,7 @@ static void
 release_write_buf(test_data *td, struct iovec* vecs, int n_vecs)
 {
   struct tcp_state *ps = (struct tcp_state *)td->data;
-  assert(vecs == ps->buffer && n_vecs == 1);
+  assert(vecs == &ps->buffer && n_vecs == 1);
   xwrite(ps->fd, vecs[0].iov_base, vecs[0].iov_len);
 }
 

--- a/vmsplice_pipe_thr.c
+++ b/vmsplice_pipe_thr.c
@@ -207,7 +207,7 @@ static void release_write_buffer(test_data* td, struct iovec* vecs, int n_vecs) 
 
   pipe_state *ps = (pipe_state *)td->data;
   assert(n_vecs == 1);
-  assert(vecs == &td->iov);
+
 #ifdef VMSPLICE_COOP
   ps->bytes_written += td->size;
   while(ps->bytes_written >= coop_reporting_chunk_size) {


### PR DESCRIPTION
Compiling without NDBUG defined produced some errors which are fixed in this patch.
Also a duplicated line in the Makefile was removed.
